### PR TITLE
Introduce --ignore parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ In order to save memory and CPU time in idle (although only very few) the script
 * `-u URL` (`required`): URL of the website to watch
 * `-t TOLERANCE`: Tolerance in characters, i.e. changes with a difference of less than or equal to `TOLERANCE` characters will be ignored and not trigger a notification
 * `-x XPATH`: An [XPath](https://developer.mozilla.org/en-US/docs/Web/XPath) query to restrict watching to certain parts of a website. Only child elements of the element matching the query will be considered while watching
+* `-i XPATH_IGNORE`: A list of [XPath](https://developer.mozilla.org/en-US/docs/Web/XPath) queries to exclude certain parts of a website. Multiple queries possible by separating with a space like -i "//script" "//style". 
 * `-ua USER_AGENT`: A custom user agent header to set in requests, e.g. for pretending to be a browser. Shortcut `firefox` is available to fake a Firefox 84 on Windows 10
 * `--adapter ADAPTER`: Which sending adapter to use (see below)
 

--- a/batch.sh
+++ b/batch.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # ---------------------------------------------------
@@ -8,9 +7,9 @@
 #
 # Prerequisites:
 # --------------
-# - jq must be installed
-#   - Debian / Ubuntu: apt install jq
-#   - Fedora / RHEL: dnf install jq
+# - jq and bc must be installed
+#   - Debian / Ubuntu: apt install jq bc
+#   - Fedora / RHEL: dnf install jq bc
 # - watcher.py must be executable
 #   - chmod +x watcher.py
 # - batch.sh must be executable
@@ -29,6 +28,7 @@ for job in $jobs; do
     url=$(echo $job | jq -r '.url')
     tolerance=$(echo $job | jq -r '.tolerance')
     xpath=$(echo $job | jq -r '.xpath')
+    ignore=$(echo $job | jq -r '.ignore' | tr \; " ")
 
     if [ "$url" == "null" ]; then
         echo "Error: URL parameter missing for job $cur of $total"
@@ -45,10 +45,15 @@ for job in $jobs; do
         exit 1
     fi
 
+    if [ "$xpath" == "null" ]; then
+        echo "Error: XPATH missing for job $cur of $total (just set it to '/' to watch whole document)"
+        exit 1
+    fi
+
     echo "[$cur/$total] Watching $url."
-    
+
     start=`date +%s.%N`
-    ./watcher.py -u $url -t $tolerance -x $xpath ${@:2}
+    ./watcher.py -u $url -t $tolerance -x $xpath -i $ignore "${@:2}"
     end=`date +%s.%N`
 
     echo "[$cur/$total] Took $(echo $end-$start | bc) seconds."

--- a/batch.sh
+++ b/batch.sh
@@ -45,8 +45,8 @@ for job in $jobs; do
         exit 1
     fi
 
-    if [ "$xpath" == "null" ]; then
-        echo "Error: XPATH missing for job $cur of $total (just set it to '/' to watch whole document)"
+    if [ "$ignore" == "null" ]; then
+        echo "Error: XPATH ignore list missing for job $cur of $total (separate XPATH expressions by a space)"
         exit 1
     fi
 

--- a/example/many.json
+++ b/example/many.json
@@ -2,11 +2,13 @@
     {
         "url": "http://www.kit.edu/kit/english/22403.php",
         "tolerance": 10,
-        "xpath": "//body"
+        "xpath": "//body",
+        "ignore": "//script;//style;"
     },
     {
         "url": "https://muetsch.io/about/",
         "tolerance": 0,
-        "xpath": "//div[@class='content']"
+        "xpath": "//div[@class='content']",
+        "ignore": "//script;//style;"
     }
 ]


### PR DESCRIPTION
Introduce --ignore parameter in order to filter out XPath elements we do not want to monitor.